### PR TITLE
Fix(config): Handled trim correclty on ubuntu

### DIFF
--- a/config/index.js
+++ b/config/index.js
@@ -6,7 +6,7 @@ const route = path.join(__dirname, 'env', env.trim())
 const config = require(route)
 // trim the space at the end of variables in windows
 for (const key in config) {
-  config[key] = config[key].trim()
+  config[key] = config[key] ? config[key].trim() : config[key]
 }
 
 module.exports = module.exports = Object.assign({}, common, config)

--- a/test/unit/avax-unit.js
+++ b/test/unit/avax-unit.js
@@ -2,7 +2,6 @@
 const chai = require('chai')
 const sinon = require('sinon')
 const cloneDeep = require('lodash.clonedeep')
-const config = require('../../config')
 
 // Locally global variables.
 const assert = chai.assert
@@ -21,7 +20,7 @@ describe('#avax.js', () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox()
     mockData = cloneDeep(mockDataLib)
-    uut.config = { ...config }
+    uut.config = { ...mockData.fakeConfig }
   })
 
   afterEach(() => sandbox.restore())

--- a/test/unit/bch-unit.js
+++ b/test/unit/bch-unit.js
@@ -1,7 +1,6 @@
 const chai = require('chai')
 const sinon = require('sinon')
 const cloneDeep = require('lodash.clonedeep')
-const config = require('../../config')
 
 // Locally global variables.
 const assert = chai.assert
@@ -21,7 +20,7 @@ describe('#bch.js', () => {
   beforeEach(() => {
     sandbox = sinon.createSandbox()
     mockData = cloneDeep(mockDataLib)
-    uut.config = { ...config }
+    uut.config = { ...mockData.fakeConfig }
   })
 
   afterEach(() => sandbox.restore())

--- a/test/unit/mocks/avax-mocks.js
+++ b/test/unit/mocks/avax-mocks.js
@@ -1,15 +1,20 @@
-const config = require('../../../config')
-
 const { BN, BinTools } = require('avalanche')
 const avm = require('avalanche/dist/apis/avm')
 const binTools = BinTools.getInstance()
 
-const addressStrings = ['X-avax13c29zyftvjfs4un7aekjm8yn6vpsn3czug7l6e']
-const addresses = [binTools.cb58Decode('DxFHsGqRDGW77gmLYCEWvoWkZUkvUTLj5')]
+const fakeConfig = {
+  AVAX_IP: 'localhost',
+  AVAX_PORT: '4650',
+  AVAX_PRIVATE_KEY:
+    'PrivateKey-kXESwYRt4TkPXG4A9EXx1pXqP2aMUcGYTBpAGZxuKjyCwvVP',
+  AVAX_TOKEN: '2jgTFB6MM4vwLzUNWFYGPfyeQfpLaEqj4XWku6FoW7vaGrrEd5'
+}
+const addressStrings = ['X-avax1d73xzy6tqchgxrdr0um3hjae0qzpyvp2x5j9as']
+const addresses = [binTools.cb58Decode('BBGXbg6d3RGvxh5xGURCjNMo3pJTorfrF')]
 
 const avaxString = 'FvwEAhmxKfeiG8SnEvq42hc6whRyY3EFYAvebMqDNDGCgxN5Z'
 const avaxID = binTools.cb58Decode(avaxString)
-const assetId = binTools.cb58Decode(config.AVAX_TOKEN)
+const assetId = binTools.cb58Decode(fakeConfig.AVAX_TOKEN)
 
 const txid = 'aCvBmRoD6ARCXjCVJqEHWnrVeH6Ax5Mon5pYgRuz18RnZtWrw'
 
@@ -85,5 +90,6 @@ module.exports = {
   UTXOWithMintToken,
   UTXOWithToken,
   avaxID,
-  cb58Transaction
+  cb58Transaction,
+  fakeConfig
 }

--- a/test/unit/mocks/bch-mocks.js
+++ b/test/unit/mocks/bch-mocks.js
@@ -1,5 +1,12 @@
 'use strict'
 
+const fakeConfig = {
+  network: 'mainnet',
+  networkURL: 'https://api.fullstack.cash/v4/',
+  tokenID: '600ee24d0f208aebc2bdd2c4ee1b9acb6d57343561442e8676b5bbea311d5a0f',
+  WIF: 'L5EDpCV9UURj6FhMo7CZk4QsH95orcVsm2qjKirngaXgeA3A6ZhZ'
+}
+
 const mockUtxos = {
   success: true,
   utxos: []
@@ -181,5 +188,6 @@ module.exports = {
   mockTokenlessUtxos,
   mockNotEnoughBalance,
   mockValidUtxos,
-  mockTxid
+  mockTxid,
+  fakeConfig
 }


### PR DESCRIPTION
I added a handler for the trim method call in the config instance, it shouldn't throw an error now. And now the unit test run on some mock configuration data that has been set up.