### PR TITLE
Fix(avax): Only read type 7 when burning

### DIFF
--- a/lib/avax.js
+++ b/lib/avax.js
@@ -218,7 +218,7 @@ class AvaxLib {
       // get the inputs for the transcation
       const inputs = utxos.reduce((txInputs, utxo) => {
         // typeID 6 is a minting baton utxo, it gets skipped
-        if (utxo.getOutput().getTypeID() === 6) {
+        if (utxo.getOutput().getTypeID() !== 7) {
           return txInputs
         }
 


### PR DESCRIPTION
Pull request related to [this trello task](https://trello.com/c/zh6S3ccO)